### PR TITLE
Remove Babel external helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Now, when your target gets builded, the plugin will check if the target is using
 
 Let's say you have a `backend` target with your Node server code, and a `frontend` target with your React code, and you want to require your `frontend` code on the `backend` in order to use `ReactDOM.renderToString(...)`:
 
-For your `backend` target you'll have to define its `framework` property to `react`, so the plugin can include the JSX loader, and then make sure you included the `frontend` target on the `includeTargets` setting:
+For your `backend` target you'll have to define its `framework` property to `react`, so the plugin can include the JSX preset, and then make sure you included the `frontend` target on the `includeTargets` setting:
 
 ```js
 module.exports = {
@@ -55,7 +55,7 @@ Done, now you can `require`/`import` files from your `frontend` target on the `b
 
 ### Babel
 
-This plugin adds the [`react`](https://yarnpkg.com/en/package/babel-preset-react) preset for JSX support, and the [`external-helpers`](https://yarnpkg.com/en/package/external-helpers) plugin, for better compatibility with Rollup.
+This plugin adds the [`react`](https://yarnpkg.com/en/package/babel-preset-react) preset for JSX support.
 
 ### External dependencies
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-preset-react": "6.24.1",
-    "babel-plugin-external-helpers": "6.22.0"
+    "babel-preset-react": "6.24.1"
   },
   "devDependencies": {
     "wootils": "^1.3.2",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,13 +35,6 @@ class ProjextReactPlugin {
      */
     this._babelConfigurationEvent = 'babel-configuration';
     /**
-     * The required Babel plugin for the JSX integration of with Rollup.
-     * @type {string}
-     * @access protected
-     * @ignore
-     */
-    this._babelPlugin = 'external-helpers';
-    /**
      * The name of the Babel preset required to add support for React's JSX.
      * @type {string}
      * @access protected
@@ -80,7 +73,7 @@ class ProjextReactPlugin {
   }
   /**
    * This method gets called when projext reduces a target Babel configuration. The method will
-   * validate the target settings and add the Babel plugins needed for JSX.
+   * validate the target settings and add the Babel preset needed for JSX.
    * @param {Object}      currentConfiguration The current Babel configuration for the target.
    * @param {Target}      target               The target information.
    * @param {BabelHelper} babelHelper          To update the target configuration and add the
@@ -93,7 +86,6 @@ class ProjextReactPlugin {
     let updatedConfiguration;
     if (target.framework === this._frameworkProperty) {
       updatedConfiguration = babelHelper.addPreset(currentConfiguration, this._babelPreset);
-      updatedConfiguration = babelHelper.addPlugin(updatedConfiguration, this._babelPlugin);
     } else {
       updatedConfiguration = currentConfiguration;
     }

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -83,7 +83,6 @@ describe('plugin:projextReact/main', () => {
     };
     const babelHelper = {
       addPreset: jest.fn((config, name) => Object.assign({}, config, { preset: name })),
-      addPlugin: jest.fn((config, name) => Object.assign({}, config, { plugin: name })),
     };
     const services = {
       events,
@@ -99,11 +98,8 @@ describe('plugin:projextReact/main', () => {
     let sut = null;
     let reducer = null;
     let result = null;
-    const expectedConfigWithPreset = Object.assign({}, initialBabelConfiguration, {
+    const expectedConfig = Object.assign({}, initialBabelConfiguration, {
       preset: 'react',
-    });
-    const expectedConfigWithPlugin = Object.assign({}, expectedConfigWithPreset, {
-      plugin: 'external-helpers',
     });
     // When
     sut = new ProjextReactPlugin();
@@ -111,11 +107,9 @@ describe('plugin:projextReact/main', () => {
     [[, reducer]] = events.on.mock.calls;
     result = reducer(initialBabelConfiguration, target);
     // Then
-    expect(result).toEqual(expectedConfigWithPlugin);
+    expect(result).toEqual(expectedConfig);
     expect(babelHelper.addPreset).toHaveBeenCalledTimes(1);
     expect(babelHelper.addPreset).toHaveBeenCalledWith(initialBabelConfiguration, 'react');
-    expect(babelHelper.addPlugin).toHaveBeenCalledTimes(1);
-    expect(babelHelper.addPlugin).toHaveBeenCalledWith(expectedConfigWithPreset, 'external-helpers');
   });
 
   it('shouldn\'t modify a target externals if the framework setting is invalid', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,12 +417,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-external-helpers@6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
### What does this PR do?

It removes the Babel external helpers plugin, since it's already being added by the main Rollup plugin (homer0/projext-plugin-rollup#3).

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
